### PR TITLE
Fix module typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'json-stringify-pretty-compact' {
+declare module '@aitodotai/json-stringify-pretty-compact' {
   const stringify: (object: any, options?: {
       indent?: number | string,
       maxLength?: number,


### PR DESCRIPTION
Change module in typings to have correct org prefix.

If would be great if you could also do a new npm release out of the package, to get the index.d.ts file into the npm package as well. Currently it's necessary to depend on a github repo or fix the module typings in a project code instead.

